### PR TITLE
List individual tools in the readme

### DIFF
--- a/.github/scripts/update_readme.py
+++ b/.github/scripts/update_readme.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import json
 import sys
+import yaml
 
 from jinja2 import Template
 
@@ -28,13 +29,30 @@ with open(".github/templates/README.md.j2", "r") as f:
     template = Template(f.read())
 
 with open(readme_path, "w") as f:
-    htmlout = "<thead><tr><th>Chunk ID</th><th>Tool List</th><th>Latest report</th><th>Previous report</th></tr></thead><tbody>"
     ids = list(chunks.keys())
     ids = [int(x) for x in ids]
     ids.sort()
     ids = [str(x) for x in ids]
+    # Write the chunked test reports table
+    reports_html = "<thead><tr><th>Chunk ID</th><th>Tool List</th><th>Latest report</th><th>Previous report</th></tr></thead><tbody>"
     for eachid in ids:
         eachchunk = chunks.get(eachid)
-        htmlout += "<tr><td>{}</td><td><a href=\"{}\">Toolset</a></td><td><a href=\"{}\">{}</a></td><td><a href=\"{}\">{}</a></td></tr>".format(eachid, eachchunk.get("tools"), eachchunk.get("run1"), eachchunk.get("date1"), eachchunk.get("run2"), eachchunk.get("date2"))
-    htmlout += "</tbody>"
-    f.write(template.render(anviltools=htmlout, reportdir=readme_path.replace("/README.md", "")))
+        reports_html += "<tr><td>{}</td><td><a href=\"{}\">Toolset</a></td><td><a href=\"{}\">{}</a></td><td><a href=\"{}\">{}</a></td></tr>".format(
+            eachid, eachchunk.get("tools"), eachchunk.get("run1"), eachchunk.get("date1"), eachchunk.get("run2"), eachchunk.get("date2"))
+    reports_html += "</tbody>"
+    # List tools individually
+    tool_tests_html = "<thead<tr><th>#</th><th>Tool ID</th><th>Test results</th></thead><tbody>"
+    count = 0
+    for each_id in ids:
+        chunk = chunks.get(each_id)
+        chunk_tools_url = chunk.get('tools')
+        chunk_tools_path = chunk_tools_url.replace('https://github.com/anvilproject/galaxy-tests/blob/main/', '')
+        with open(chunk_tools_path, 'r') as tf:
+            chunk_tools = yaml.safe_load(tf)
+            for tool in chunk_tools['tools']:
+                for rev in tool['revisions']:
+                    count += 1
+                    tool_tests_html += f"<tr><td>{count}</td><td>{tool['owner']}/{tool['name']}@{rev}</td><td></td></tr>"
+    tool_tests_html += "</tbody>"
+
+    f.write(template.render(toolreports=reports_html, tooltests=tool_tests_html, reportdir=readme_path.replace("/README.md", "")))

--- a/.github/templates/README.md.j2
+++ b/.github/templates/README.md.j2
@@ -1,17 +1,21 @@
 # Automated Tests for Galaxy on Kubernetes Stacks
-## Galaxy on GKE deployed via GalaxyKubeMan (AnVIL)
-### Deployment Testing
-Twice a day, [GalaxyKubeMan (GKM)](https://github.com/galaxyproject/galaxykubeman-helm) is deployed on GKE, mimicking an AnVIL deployment. The purpose of these tests is to provide reasonable confidence that Galaxy is launchable on the AnVIL everyday.
+## Deployment testing
+Twice a day, [GalaxyKubeMan (GKM)](https://github.com/galaxyproject/galaxykubeman-helm) is deployed on GKE, mimicking an AnVIL deployment. The purpose of these tests is to provide reasonable confidence that Galaxy can be launched on the AnVIL everyday.
 
 Below is a plot summarizing successful deployments and GKM install times.
 <a href="https://htmlpreview.github.io/?https://github.com/anvilproject/galaxy-tests/blob/main/{{reportdir}}/deployments.html">Click here</a> or on the image for more details.
 
 <a href="https://htmlpreview.github.io/?https://github.com/anvilproject/galaxy-tests/blob/main/{{reportdir}}/deployments.html"><img src="deployments.svg" /></a>
 
-### Tool Testing
-After each successful deployment, automated tool tests are also run against the instance. These serve as an end-to-end-like test for Galaxy, providing confidence that Galaxy is not only launchable but functional. These tests cycle on a weekly basis through the entire suite of tools installed by default on AnVIL, providing reasonable confidence that the tools encountered by most users remain functional, and automating the detection and reporting of tools breaking.
+## Tool testing
+After each successful deployment, automated tool tests are also run against the instance. These serve as an end-to-end-like test for Galaxy, providing confidence that Galaxy deployments are functional. These tests cycle on a weekly basis through the entire suite of tools installed by default on AnVIL, providing reasonable confidence that the tools encountered by most users remain functional, and automating the detection and reporting of tools breaking.
 
-Latest tool tests for each chunk:
+### Tool test reports
 
-<table id="anviltools">{{ anviltools }}</table>
+Latest tool test reports for each chunk:
 
+<table id="toolreports">{{ toolreports }}</table>
+
+### Inidividual tool tests results over time:
+
+<table id="tooltests">{{ tooltests }}</table>


### PR DESCRIPTION
This will include a list of individual tools in the readme, so longitudinal tool test results can be easily seen. 

This is what the top few lines of the table look like: 
![image](https://user-images.githubusercontent.com/338642/178004004-e229b869-7337-4f55-b6fb-d3de5fab2a5e.png)

This can be generated locally by running the following command from the repo root:
```
python .github/scripts/update_readme.py reports/anvil-production/tool-tests/gxy-auto-2022-07-05-04-34-51-1/chunk.json reports/anvil-production/tool-tests/chunks.json reports/anvil-production/README.md
```