### PR TITLE
Version updates

### DIFF
--- a/.github/workflows/new-edgetest.yaml
+++ b/.github/workflows/new-edgetest.yaml
@@ -82,6 +82,7 @@ jobs:
               --wait-for-jobs\
               --timeout 720s\
               --version $GKM_VERSION\
+              --values .github/templates/job_metrics.conf.yml\
               --set galaxy.service.type=LoadBalancer\
               --set galaxy.configs.\"galaxy\.yml\".galaxy.admin_users=\"tests@fake.org\"\
               --set galaxy.configs.\"galaxy\.yml\".galaxy.master_api_key=galaxypassword\

--- a/.github/workflows/new-edgetest.yaml
+++ b/.github/workflows/new-edgetest.yaml
@@ -14,7 +14,7 @@ jobs:
   deploygke:
     env:
       GKE_ZONE: us-east1-b
-      GKE_VERSION: "1.24"
+      GKE_VERSION: "1.25"
       GXY_TMP: /tmp/gxy
       PREFIX: edge
     runs-on: ubuntu-latest
@@ -117,7 +117,7 @@ jobs:
         run: kubectl get events -n ${{needs.deploygke.outputs.prefix}}-1
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install required system packages
         run: sudo apt-get update && sudo apt-get install -y python3-h5py pkg-config libhdf5-dev
       - name: Install dependencies

--- a/.github/workflows/new-productiontest.yaml
+++ b/.github/workflows/new-productiontest.yaml
@@ -12,7 +12,7 @@ on:
         default: '3'
 env:
   GKE_ZONE: us-east1-b
-  GKE_VERSION: "1.24"
+  GKE_VERSION: "1.25"
   GKM_VERSION: "2.0.0"
   IMAGE_TAG: "21.09"
   GXY_TMP: /tmp/gxy
@@ -120,7 +120,7 @@ jobs:
         run: kubectl get events -n ${{needs.deploygke.outputs.prefix}}-1
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
       - name: Install required system packages
         run: sudo apt-get update && sudo apt-get install -y python3-h5py pkg-config libhdf5-dev
       - name: Install dependencies


### PR DESCRIPTION
Pin Python at version 3.11 as aiohttp is not compatible with 3.12 yet.  Update GKE to 1.25 since 1.24 has reached EOL.